### PR TITLE
👷 build arm64 images with github actions arm64 runners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,13 +30,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        config:
+          - platform: linux/amd64
+            runs-on: ubuntu-24.04
+          - platform: linux/arm64
+            runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -62,7 +63,7 @@ jobs:
           context: .
           file: ${{ inputs.dockerfilePath }}
           target: ${{ inputs.buildTarget }}
-          platforms: ${{ matrix.platform }}
+          platforms: ${{ matrix.config.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ inputs.buildArgs }}
           outputs: type=image,name=${{ inputs.imageRegistry }},push-by-digest=true,name-canonical=true,push=true
@@ -72,7 +73,7 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
       - name: Set sanitized platform
-        run: echo "SANITIZED_PLATFORM=${{ matrix.platform }}" | sed 's/\//-/g' >> $GITHUB_ENV
+        run: echo "SANITIZED_PLATFORM=${{ matrix.config.platform }}" | sed 's/\//-/g' >> $GITHUB_ENV
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
@@ -81,6 +82,7 @@ jobs:
           retention-days: 1
 
   merge:
+    if: github.ref_name == 'main'
     runs-on: ubuntu-latest
     needs:
       - build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,7 @@ on:
 
 jobs:
   build:
+    runs-on: ${{ matrix.config.runs-on }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,9 +3,11 @@ name: ci
 on:
   push:
     branches:
-      - main
+      - '**'
   schedule:
     - cron: 0 0 * * 0
+      branches:
+        - main
 
 jobs:
   yamllint:


### PR DESCRIPTION
## WHAT

Change `build.yaml` action to build arm64 images with github actions arm64 runners.

## WHY

Since the [linux arm64 hosted runners are now available in public preview](linux-arm64-hosted-runners), we can take adavantage of them to significantly decrease the build time.

## TESTS

Already triggered github actions with the new arm64 runners on this branch.

## REMARKS

/
